### PR TITLE
Sendfile bug : Moving to debian base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Bats Docker Image CHANGELOG
 
+## 2015-06-14
+* Moving base image to debian 8.1 to avoid sendfile problems
+
 ## 2015-05-29
 * Updating base image : from alpine 3.1 to 3.2
 * Improve version testing

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-FROM alpine:3.2
+FROM debian:8.1
 MAINTAINER Damien DUPORTAL <damien.duportal@gmail.com>
 
 ENV BATS_VERSION 0.4.0
+ENV DEBIAN_FRONTEND noninteractive
 
-ADD https://github.com/sstephenson/bats/archive/v${BATS_VERSION}.tar.gz /tmp/
-
-RUN apk --update add make bash curl \
-	&& tar -x -z -f /tmp/v${BATS_VERSION}.tar.gz -C /tmp/ \
-	&& bash /tmp/bats-${BATS_VERSION}/install.sh /usr/local \
+RUN apt-get update -q \
+	&& apt-get install -y -q --no-install-recommends bash make curl ca-certificates \
+	&& curl -o "/tmp/v${BATS_VERSION}.tar.gz" -L \
+		"https://github.com/sstephenson/bats/archive/v${BATS_VERSION}.tar.gz" \
+	&& tar -x -z -f "/tmp/v${BATS_VERSION}.tar.gz" -C /tmp/ \
+	&& bash "/tmp/bats-${BATS_VERSION}/install.sh" /usr/local \
 	&& rm -rf /tmp/*
 
 ENTRYPOINT ["/usr/local/bin/bats"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build test all
 
-DOCKER_IMAGE_NAME=local-bats
+DOCKER_IMAGE_NAME=dduportal/bats
 
 all: build test
 
@@ -14,5 +14,5 @@ test:
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-e DOCKER_HOST=unix:///var/run/docker.sock \
 		-e DOCKER_IMAGE_NAME=$(DOCKER_IMAGE_NAME) \
-		dduportal/bats:0.4.0 \
+		dduportal/bats \
 			/app/tests/bats/

--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,5 @@ test:
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-e DOCKER_HOST=unix:///var/run/docker.sock \
 		-e DOCKER_IMAGE_NAME=$(DOCKER_IMAGE_NAME) \
-		dduportal/bats \
+		dduportal/bats:0.4.0 \
 			/app/tests/bats/

--- a/README.md
+++ b/README.md
@@ -53,9 +53,8 @@ $ docker run -t my-tests
 
 ### Base image
 
-Since this image just need bats and little dependencies, we use [Alpine Linux](https://registry.hub.docker.com/_/alpine/) as a base image :
-* It is a light image (~5 Mb)
-* It embed an usefull and complete package manager : [apk](http://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management) which has [a lot of available packages](http://forum.alpinelinux.org/packages)
+This image is built upom debian image, to have a balance beetween size and customization.
+It also avoid aving sendfile caching bug when using with virtualbox (default boot2docker hypervisor) shared folder (See https://www.virtualbox.org/ticket/12597 )
 
 ### Already installed package
 

--- a/tests/bats/test-bats-dockerimage.bats
+++ b/tests/bats/test-bats-dockerimage.bats
@@ -7,9 +7,10 @@ BATS_VERSION=0.4.0
 	[ "${output:0:4}" == "Bats" ]
 }
 
-ALPINE_VERSION=3.2
-@test "We use the alpine linux version ${ALPINE_VERSION}" {
-	[ $(docker run --entrypoint sh "${DOCKER_IMAGE_NAME}" -c "grep VERSION_ID /etc/os-release | grep -e \"=${ALPINE_VERSION}.\" | wc -l") -eq 1 ]
+DEBIAN_VERSION=8.1
+@test "We use the debian linux version ${DEBIAN_VERSION}" {
+	[ $(docker run --entrypoint sh "${DOCKER_IMAGE_NAME}" -c "grep \"${DEBIAN_VERSION}\" /etc/debian_version | wc -l") -eq 1 ]
+
 }
 
 @test "A sample bats test" {


### PR DESCRIPTION
This PR introduce :
- Moving to debian 8.1 base image, less lightweight but avoid sendfile bugs and enable better customization
