### PR TITLE
Fix error "temp_make fails with "unrecognized option: directory"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /bats
 RUN npm install
 
 # Minimalistic image
-FROM alpine:3.7
+FROM alpine:3.10
 LABEL Maintainer="Damien DUPORTAL <damien.duportal@gmail.com>"
 ENV BATS_HELPERS_DIR=/opt/bats-helpers
 
@@ -20,7 +20,7 @@ COPY --from=dependencies-solver /bats/node_modules/bats-file /opt/bats-helpers/b
 COPY --from=dependencies-solver /bats/node_modules/bats-assert /opt/bats-helpers/bats-assert
 
 
-RUN apk add --no-cache bash \
+RUN apk add --no-cache bash coreutils \
   && ln -s /opt/bats/libexec/bats /sbin/bats
 
 WORKDIR /tests

--- a/tests/test-bats-dockerimage.bats
+++ b/tests/test-bats-dockerimage.bats
@@ -15,6 +15,16 @@ setup() {
 	run_command_with_docker | grep "Bats" | grep "${BATS_VERSION}"
 }
 
+@test "Bash is installed" {
+  local CUSTOM_DOCKER_RUN_OPTS="--entrypoint which"
+	run_command_with_docker bash
+}
+
+@test "mktemp accepts the long flag --directory" {
+  local CUSTOM_DOCKER_RUN_OPTS="--entrypoint bash"
+  run_command_with_docker -c 'mktemp --directory'
+}
+
 @test "Environment variable for Bats Helper is set and valid" {
   local CUSTOM_DOCKER_RUN_OPTS="--entrypoint bash"
   run_command_with_docker -c 'test -d "${BATS_HELPERS_DIR}"'
@@ -43,9 +53,4 @@ setup() {
 @test "We can run a sample test at run time by mounting it" {
   local CUSTOM_DOCKER_RUN_OPTS="-v $(pwd)/sample:/tests"
 	run_command_with_docker /tests/
-}
-
-@test "Bash is installed" {
-  local CUSTOM_DOCKER_RUN_OPTS="--entrypoint which"
-	run_command_with_docker bash
 }


### PR DESCRIPTION
This PR closes #7 .

By installing the package `coreutils` (overhead: ~2 Mb), the binary `mktemp` is accepting the long flag `--directory` (which was not the case with the default busybox `mktemp`).

Credits to @znerd, thanks!