### PR TITLE
Bump Bats

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,13 @@ COPY --from=dependencies-solver /bats/node_modules/bats-file /opt/bats-helpers/b
 COPY --from=dependencies-solver /bats/node_modules/bats-assert /opt/bats-helpers/bats-assert
 
 
-RUN apk add --no-cache bash coreutils \
-  && ln -s /opt/bats/libexec/bats /sbin/bats
+RUN apk add --no-cache bash coreutils
+
+WORKDIR /opt/bats
+RUN ./install.sh /sbin
+RUN ln -s /sbin/bin/bats /sbin/bats
 
 WORKDIR /tests
-
 
 ENTRYPOINT ["/sbin/bats"]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,28 @@
 {
   "name": "dduportal-bats",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "bats": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/bats/-/bats-0.4.2.tgz",
-      "integrity": "sha1-gfIiu8uwg9FSiz6IMKbo8xSHbsY=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.5.0.tgz",
+      "integrity": "sha512-83YgQw24Yi2c1ctB0Vd7WCsACUMSWuEtOboxQZyFQYfiv9hDMW7nk7bdloqGLg3vK5pOODCBGBQjhvRmHKsJuA==",
       "dev": true
     },
     "bats-assert": {
-      "version": "git+https://github.com/ztombol/bats-assert.git#cf1718da00bf1a7d33186ef13bb21841a77861c6",
+      "version": "git+ssh://git@github.com/ztombol/bats-assert.git#cf1718da00bf1a7d33186ef13bb21841a77861c6",
+      "from": "bats-assert@git+https://github.com/ztombol/bats-assert.git#v0.3.0",
       "dev": true
     },
     "bats-file": {
-      "version": "git+https://github.com/ztombol/bats-file.git#2fddb2b831d65cdf2e411f3b47f4677fbb15729c",
+      "version": "git+ssh://git@github.com/ztombol/bats-file.git#2fddb2b831d65cdf2e411f3b47f4677fbb15729c",
+      "from": "bats-file@git+https://github.com/ztombol/bats-file.git#v0.2.0",
       "dev": true
     },
     "bats-support": {
-      "version": "git+https://github.com/ztombol/bats-support.git#24a72e14349690bcbf7c151b9d2d1cdd32d36eb1",
+      "version": "git+ssh://git@github.com/ztombol/bats-support.git#24a72e14349690bcbf7c151b9d2d1cdd32d36eb1",
+      "from": "bats-support@git+https://github.com/ztombol/bats-support.git#v0.3.0",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "dduportal-bats",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "This file is use for dependency management only and will never be used on the end Docker image",
   "private": "true",
   "author": "Damien DUPORTAL <damien.duportal@gmail.com>",
   "license": "ISC",
   "devDependencies": {
-    "bats": "^0.4.2",
+    "bats": "^1.5.0",
     "bats-support": "git+https://github.com/ztombol/bats-support.git#v0.3.0",
     "bats-assert": "git+https://github.com/ztombol/bats-assert.git#v0.3.0",
     "bats-file": "git+https://github.com/ztombol/bats-file.git#v0.2.0"

--- a/tests/test-bats-dockerimage.bats
+++ b/tests/test-bats-dockerimage.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-BATS_VERSION=0.4.0
+BATS_VERSION=1.5.0
 
 run_command_with_docker() {
   docker run --rm -t ${CUSTOM_DOCKER_RUN_OPTS} \
@@ -51,6 +51,6 @@ setup() {
 }
 
 @test "We can run a sample test at run time by mounting it" {
-  local CUSTOM_DOCKER_RUN_OPTS="-v $(pwd)/sample:/tests"
-	run_command_with_docker /tests/
+  local CUSTOM_DOCKER_RUN_OPTS="-v $(pwd):/tests"
+	run_command_with_docker /samples
 }


### PR DESCRIPTION
* Updating Bats to v1.5.0
* Correct execution in assertion `We can run a sample test at run time by mounting it` so that the actual _samples_ folder is mounted. This seemingly was sort of a blind spot with the older version of bats but would have resulted in an error if not corrected.
